### PR TITLE
Add api for text fragments

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -43,8 +43,8 @@ dependencies {
     implementation("io.ktor:ktor-server-status-pages:$ktor_version")
     implementation("ch.qos.logback:logback-classic:$logback_version")
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:$kotlinxDatetimeVersion")
-    testImplementation("io.ktor:ktor-server-test-host-jvm")
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
+    testImplementation("io.ktor:ktor-server-test-host:$ktor_version")
+    testImplementation("org.jetbrains.kotlin:kotlin-test:$kotlin_version")
 }
 
 tasks {

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:$kotlinxDatetimeVersion")
     testImplementation("io.ktor:ktor-server-test-host:$ktor_version")
     testImplementation("org.jetbrains.kotlin:kotlin-test:$kotlin_version")
+    testImplementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
 }
 
 tasks {

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -3,7 +3,8 @@ val ktor_version: String by project
 val logback_version: String by project
 val exposed_version: String by project
 val postgresql_version: String by project
-val kotlinxDatetimeVersion: String by project
+val kotlinx_datetime_version: String by project
+val serialization_version: String by project
 
 plugins {
     kotlin("jvm") version "2.0.20"
@@ -26,23 +27,26 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-server-core-jvm")
-    implementation("io.ktor:ktor-serialization-kotlinx-json-jvm")
-    implementation("io.ktor:ktor-server-content-negotiation-jvm")
+    implementation("io.ktor:ktor-server-core:$ktor_version")
+    implementation("io.ktor:ktor-serialization:$ktor_version")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
+    implementation("io.ktor:ktor-server-content-negotiation:$ktor_version")
+    implementation("io.ktor:ktor-server-call-logging:$ktor_version")
+    implementation("io.ktor:ktor-server-cors:$ktor_version")
+    implementation("io.ktor:ktor-server-host-common:$ktor_version")
+    implementation("io.ktor:ktor-server-sessions:$ktor_version")
+    implementation("io.ktor:ktor-server-auth:$ktor_version")
+    implementation("io.ktor:ktor-server-auth-jwt:$ktor_version")
+    implementation("io.ktor:ktor-server-netty:$ktor_version")
+    implementation("io.ktor:ktor-server-status-pages:$ktor_version")
     implementation("org.jetbrains.exposed:exposed-core:$exposed_version")
     implementation("org.jetbrains.exposed:exposed-jdbc:$exposed_version")
     implementation("org.jetbrains.exposed:exposed-java-time:$exposed_version")
     implementation("org.postgresql:postgresql:$postgresql_version")
-    implementation("io.ktor:ktor-server-call-logging-jvm")
-    implementation("io.ktor:ktor-server-cors-jvm")
-    implementation("io.ktor:ktor-server-host-common-jvm")
-    implementation("io.ktor:ktor-server-sessions-jvm")
-    implementation("io.ktor:ktor-server-auth-jvm")
-    implementation("io.ktor:ktor-server-auth-jwt-jvm")
-    implementation("io.ktor:ktor-server-netty-jvm")
-    implementation("io.ktor:ktor-server-status-pages:$ktor_version")
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    implementation("org.jetbrains.kotlinx:kotlinx-datetime:$kotlinxDatetimeVersion")
+    implementation("org.jetbrains.kotlinx:kotlinx-datetime:$kotlinx_datetime_version")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$serialization_version")
+
     testImplementation("io.ktor:ktor-server-test-host:$ktor_version")
     testImplementation("org.jetbrains.kotlin:kotlin-test:$kotlin_version")
     testImplementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
@@ -69,4 +73,3 @@ tasks {
         dependsOn(fatJar)
     }
 }
-

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -5,6 +5,9 @@ val exposed_version: String by project
 val postgresql_version: String by project
 val kotlinx_datetime_version: String by project
 val serialization_version: String by project
+val mockk_version: String by project
+val kotlinx_coroutines_test: String by project
+val junit_jupiter_api: String by project
 
 plugins {
     kotlin("jvm") version "2.0.20"
@@ -46,10 +49,14 @@ dependencies {
     implementation("ch.qos.logback:logback-classic:$logback_version")
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:$kotlinx_datetime_version")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$serialization_version")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinx_coroutines_test")
 
     testImplementation("io.ktor:ktor-server-test-host:$ktor_version")
     testImplementation("org.jetbrains.kotlin:kotlin-test:$kotlin_version")
     testImplementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
+    testImplementation("io.mockk:mockk:$mockk_version")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:$junit_jupiter_api")
+
 }
 
 tasks {

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
     implementation("io.ktor:ktor-server-call-logging-jvm")
     implementation("io.ktor:ktor-server-cors-jvm")
     implementation("io.ktor:ktor-server-host-common-jvm")
-    implementation("io.ktor:ktor-server-status-pages-jvm")
     implementation("io.ktor:ktor-server-sessions-jvm")
     implementation("io.ktor:ktor-server-auth-jvm")
     implementation("io.ktor:ktor-server-auth-jwt-jvm")

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -8,6 +8,7 @@ val serialization_version: String by project
 val mockk_version: String by project
 val kotlinx_coroutines_test: String by project
 val junit_jupiter_api: String by project
+val h2_version: String by project
 
 plugins {
     kotlin("jvm") version "2.0.20"
@@ -56,6 +57,7 @@ dependencies {
     testImplementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
     testImplementation("io.mockk:mockk:$mockk_version")
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junit_jupiter_api")
+    testImplementation("com.h2database:h2:$h2_version")
 
 }
 

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -58,7 +58,6 @@ dependencies {
     testImplementation("io.mockk:mockk:$mockk_version")
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junit_jupiter_api")
     testImplementation("com.h2database:h2:$h2_version")
-
 }
 
 tasks {

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -1,8 +1,9 @@
 kotlin.code.style=official
+
 ktor_version=3.0.0-rc-1
 kotlin_version=2.0.20
 logback_version=1.4.14
 exposed_version=0.53.0
 postgresql_version=42.7.2
-kotlinxDatetimeVersion=0.6.1
+kotlinx_datetime_version=0.6.1
 serialization_version=1.7.3

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -5,3 +5,4 @@ logback_version=1.4.14
 exposed_version=0.53.0
 postgresql_version=42.7.2
 kotlinxDatetimeVersion=0.6.1
+serialization_version=1.7.3

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -7,3 +7,6 @@ exposed_version=0.53.0
 postgresql_version=42.7.2
 kotlinx_datetime_version=0.6.1
 serialization_version=1.7.3
+mockk_version=1.13.13
+kotlinx_coroutines_test=1.9.0
+junit_jupiter_api=5.11.3

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -10,3 +10,4 @@ serialization_version=1.7.3
 mockk_version=1.13.13
 kotlinx_coroutines_test=1.9.0
 junit_jupiter_api=5.11.3
+h2_version=2.3.232

--- a/backend/src/main/kotlin/com/example/Application.kt
+++ b/backend/src/main/kotlin/com/example/Application.kt
@@ -8,7 +8,7 @@ import com.example.config.configureSerialization
 import com.example.config.initDatabase
 import com.example.repository.TextRepositoryImpl
 import com.example.repository.UserRepositoryImpl
-import com.example.routes.configureRouting
+import com.example.config.configureRouting
 import com.example.service.TextServiceImpl
 import com.example.service.UserServiceImpl
 import io.ktor.server.application.*

--- a/backend/src/main/kotlin/com/example/Application.kt
+++ b/backend/src/main/kotlin/com/example/Application.kt
@@ -9,6 +9,8 @@ import com.example.config.initDatabase
 import com.example.repository.TextRepositoryImpl
 import com.example.repository.UserRepositoryImpl
 import com.example.config.configureRouting
+import com.example.repository.TextFragmentRepositoryImpl
+import com.example.service.TextFragmentServiceImpl
 import com.example.service.TextServiceImpl
 import com.example.service.UserServiceImpl
 import io.ktor.server.application.*
@@ -26,7 +28,10 @@ fun Application.module() {
     var textRepository = TextRepositoryImpl(database)
     var textService = TextServiceImpl(textRepository)
 
-    configureRouting(userService, textService)
+    var textFragmentRepository = TextFragmentRepositoryImpl(database)
+    var textFragmentService = TextFragmentServiceImpl(textFragmentRepository)
+
+    configureRouting(userService, textService, textFragmentService )
     configureExceptionHandling()
     configureSerialization()
     configureMonitoring()

--- a/backend/src/main/kotlin/com/example/config/Databases.kt
+++ b/backend/src/main/kotlin/com/example/config/Databases.kt
@@ -7,10 +7,11 @@ fun initDatabase(config: ApplicationConfig): Database {
     val dbUrl = config.property("ktor.db.url").getString()
     val dbUser = config.property("ktor.db.user").getString()
     val dbPassword = config.property("ktor.db.password").getString()
+    val driver = config.property("ktor.db.driver").getString()
 
     var database = Database.connect(
         dbUrl,
-        driver = "org.postgresql.Driver",
+        driver,
         user = dbUser,
         password = dbPassword
     )

--- a/backend/src/main/kotlin/com/example/config/Routing.kt
+++ b/backend/src/main/kotlin/com/example/config/Routing.kt
@@ -1,14 +1,16 @@
 package com.example.config
 
+import com.example.routes.textFragmentRoutes
 import com.example.routes.textRoutes
 import com.example.routes.userRoutes
+import com.example.service.TextFragmentService
 import com.example.service.TextService
 import com.example.service.UserService
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 
-fun Application.configureRouting(userService: UserService, textService: TextService) {
+fun Application.configureRouting(userService: UserService, textService: TextService, textFragmentService: TextFragmentService) {
     routing {
         get("/") {
             call.respondText("Hello World!")
@@ -16,5 +18,6 @@ fun Application.configureRouting(userService: UserService, textService: TextServ
 
         userRoutes(userService)
         textRoutes(textService)
+        textFragmentRoutes(textFragmentService)
     }
 }

--- a/backend/src/main/kotlin/com/example/config/Routing.kt
+++ b/backend/src/main/kotlin/com/example/config/Routing.kt
@@ -1,5 +1,7 @@
-package com.example.routes
+package com.example.config
 
+import com.example.routes.textRoutes
+import com.example.routes.userRoutes
 import com.example.service.TextService
 import com.example.service.UserService
 import io.ktor.server.application.*

--- a/backend/src/main/kotlin/com/example/repository/TextFragmentRepository.kt
+++ b/backend/src/main/kotlin/com/example/repository/TextFragmentRepository.kt
@@ -5,7 +5,7 @@ import org.jetbrains.exposed.sql.statements.InsertStatement
 
 interface TextFragmentRepository {
     suspend fun getTextFragmentById(id: Int): TextFragment?
-    suspend fun addTextFragment(textFragment: TextFragment): InsertStatement<Number>
+    suspend fun addTextFragment(textFragment: TextFragment): Int
     suspend fun updateTextFragment(textFragment: TextFragment): Int
     suspend fun deleteTextFragmentById(id: Int): Int
     suspend fun getAllTextFragments(): List<TextFragment>

--- a/backend/src/main/kotlin/com/example/repository/TextFragmentRepository.kt
+++ b/backend/src/main/kotlin/com/example/repository/TextFragmentRepository.kt
@@ -1,7 +1,6 @@
 package com.example.repository
 
 import com.example.model.TextFragment
-import org.jetbrains.exposed.sql.statements.InsertStatement
 
 interface TextFragmentRepository {
     suspend fun getTextFragmentById(id: Int): TextFragment?

--- a/backend/src/main/kotlin/com/example/repository/TextFragmentRepositoryImpl.kt
+++ b/backend/src/main/kotlin/com/example/repository/TextFragmentRepositoryImpl.kt
@@ -35,7 +35,7 @@ class TextFragmentRepositoryImpl(private val db: Database) : TextFragmentReposit
             it[lineNumber] = textFragment.lineNumber
             it[commentXML] = textFragment.commentXML
             it[createdAt] = textFragment.createdAt?.let { LocalDateTime.parse(it.toString()) }
-        }
+        } get TextFragments.id
     }
 
     override suspend fun updateTextFragment(textFragment: TextFragment) = transaction(db) {

--- a/backend/src/main/kotlin/com/example/repository/TextFragmentRepositoryImpl.kt
+++ b/backend/src/main/kotlin/com/example/repository/TextFragmentRepositoryImpl.kt
@@ -22,7 +22,8 @@ class TextFragmentRepositoryImpl(private val db: Database) : TextFragmentReposit
     }
 
     override suspend fun getTextFragmentById(id: Int): TextFragment? = transaction(db) {
-        TextFragments.select(TextFragments.id)
+        TextFragments
+            .selectAll()
             .where { TextFragments.id eq id }
             .mapNotNull { it.toTextFragment() }
             .singleOrNull()

--- a/backend/src/main/kotlin/com/example/repository/TextRepository.kt
+++ b/backend/src/main/kotlin/com/example/repository/TextRepository.kt
@@ -1,11 +1,10 @@
 package com.example.repository
 
 import com.example.model.Text
-import org.jetbrains.exposed.sql.statements.InsertStatement
 
 interface TextRepository {
     suspend fun getTextById(id: Int): Text?
-    suspend fun addText(text: Text): InsertStatement<Number>
+    suspend fun addText(text: Text): Int
     suspend fun updateText(text: Text): Int
     suspend fun deleteTextById(id: Int): Int
     suspend fun getAllTexts(): List<Text>

--- a/backend/src/main/kotlin/com/example/repository/TextRepositotyImpl.kt
+++ b/backend/src/main/kotlin/com/example/repository/TextRepositotyImpl.kt
@@ -19,7 +19,6 @@ import java.time.LocalDateTime
 
 
 class TextRepositoryImpl(private val db: Database) : TextRepository {
-
     init {
         transaction(db) {
             SchemaUtils.create(Texts)
@@ -39,7 +38,7 @@ class TextRepositoryImpl(private val db: Database) : TextRepository {
             it[comment] = text.comment
             it[lineIds] = Json.encodeToString(text.lineIds)
             it[pureText] = text.pureText
-            it[TextFragments.createdAt] = text.createdAt?.let { LocalDateTime.parse(it.toString()) }
+            it[createdAt] = text.createdAt?.let { LocalDateTime.parse(it.toString()) }
         } get Texts.id
     }
 

--- a/backend/src/main/kotlin/com/example/repository/TextRepositotyImpl.kt
+++ b/backend/src/main/kotlin/com/example/repository/TextRepositotyImpl.kt
@@ -27,7 +27,8 @@ class TextRepositoryImpl(private val db: Database) : TextRepository {
     }
 
     override suspend fun getTextById(id: Int): Text? = transaction(db) {
-        Texts.select(Texts.id)
+        Texts
+            .selectAll()
             .where { Texts.id eq id }
             .mapNotNull { it.toText() }
             .singleOrNull()

--- a/backend/src/main/kotlin/com/example/repository/TextRepositotyImpl.kt
+++ b/backend/src/main/kotlin/com/example/repository/TextRepositotyImpl.kt
@@ -39,7 +39,7 @@ class TextRepositoryImpl(private val db: Database) : TextRepository {
             it[lineIds] = Json.encodeToString(text.lineIds)
             it[pureText] = text.pureText
             it[TextFragments.createdAt] = text.createdAt?.let { LocalDateTime.parse(it.toString()) }
-        }
+        } get Texts.id
     }
 
     override suspend fun updateText(text: Text) = transaction(db) {

--- a/backend/src/main/kotlin/com/example/repository/UserRepository.kt
+++ b/backend/src/main/kotlin/com/example/repository/UserRepository.kt
@@ -9,5 +9,4 @@ interface UserRepository {
     suspend fun deleteUser(id: Int)
     suspend fun getAllUsers(): List<ExposedUser>
     suspend fun getUserById(i: Int): ExposedUser?
-    suspend fun addUser(user: ExposedUser)
 }

--- a/backend/src/main/kotlin/com/example/repository/UserRepository.kt
+++ b/backend/src/main/kotlin/com/example/repository/UserRepository.kt
@@ -4,7 +4,6 @@ import com.example.model.ExposedUser
 
 interface UserRepository {
     suspend fun createUser(user: ExposedUser): Int
-    suspend fun readUser(id: Int): ExposedUser?
     suspend fun updateUser(id: Int, user: ExposedUser): Boolean
     suspend fun deleteUser(id: Int)
     suspend fun getAllUsers(): List<ExposedUser>

--- a/backend/src/main/kotlin/com/example/repository/UserRepositoryImpl.kt
+++ b/backend/src/main/kotlin/com/example/repository/UserRepositoryImpl.kt
@@ -30,7 +30,4 @@ class UserRepositoryImpl(private val database: Database) : UserRepository {
         TODO("Not yet implemented")
     }
 
-    override suspend fun addUser(user: ExposedUser) {
-        TODO("Not yet implemented")
-    }
 }

--- a/backend/src/main/kotlin/com/example/repository/UserRepositoryImpl.kt
+++ b/backend/src/main/kotlin/com/example/repository/UserRepositoryImpl.kt
@@ -8,10 +8,6 @@ class UserRepositoryImpl(private val database: Database) : UserRepository {
         TODO("Not yet implemented")
     }
 
-    override suspend fun readUser(id: Int): ExposedUser? {
-        TODO("Not yet implemented")
-    }
-
     override suspend fun updateUser(
         id: Int, user: ExposedUser
     ): Boolean {

--- a/backend/src/main/kotlin/com/example/routes/Routing.kt
+++ b/backend/src/main/kotlin/com/example/routes/Routing.kt
@@ -2,18 +2,11 @@ package com.example.routes
 
 import com.example.service.TextService
 import com.example.service.UserService
-import io.ktor.http.*
 import io.ktor.server.application.*
-import io.ktor.server.plugins.statuspages.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 
 fun Application.configureRouting(userService: UserService, textService: TextService) {
-    install(StatusPages) {
-        exception<Throwable> { call, cause ->
-            call.respondText(text = "500: $cause", status = HttpStatusCode.InternalServerError)
-        }
-    }
     routing {
         get("/") {
             call.respondText("Hello World!")

--- a/backend/src/main/kotlin/com/example/routes/TextFragmentRoutes.kt
+++ b/backend/src/main/kotlin/com/example/routes/TextFragmentRoutes.kt
@@ -1,8 +1,56 @@
 package com.example.routes
 
+import com.example.model.TextFragment
 import com.example.service.TextFragmentService
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.request.receive
+import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.put
+import kotlin.text.toIntOrNull
 
 fun Route.textFragmentRoutes(textFragmentService: TextFragmentService) {
+    post("/fragments") {
+        val fragment = call.receive<TextFragment>()
+        textFragmentService.addTextFragment(fragment)
+        call.respondText("Fragment added successfully", status = HttpStatusCode.Created)
+    }
 
+    get("/fragments") {
+        val fragments = textFragmentService.getAllTextFragments()
+        call.respondText(fragments.toString(), status = HttpStatusCode.OK)
+    }
+
+    get("/fragments/{id}") {
+        val id = call.parameters["id"]?.toIntOrNull()
+        val fragment = textFragmentService.getTextFragmentById(id)
+        if (fragment != null) {
+            call.respondText(fragment.toString(), status = HttpStatusCode.OK)
+        } else {
+            call.respondText("Fragment not found", status = HttpStatusCode.NotFound)
+        }
+    }
+
+    put("/fragments/{id}") {
+        val id = call.parameters["id"]?.toIntOrNull()
+        val updatedText = call.receive<TextFragment>()
+        if (textFragmentService.updateTextFragment(updatedText.copy(id = id))) {
+            call.respondText("Fragment updated successfully", status = HttpStatusCode.OK)
+        } else {
+            call.respondText("Fragment not modified", status = HttpStatusCode.NotModified)
+        }
+
+    }
+
+    delete("/fragments/{id}") {
+        val id = call.parameters["id"]?.toIntOrNull()
+        if (textFragmentService.deleteTextFragmentById(id)) {
+            call.respondText("Fragment deleted successfully", status = HttpStatusCode.OK)
+        } else {
+            call.respondText("Fragment not deleted", status = HttpStatusCode.NotModified)
+        }
+    }
 }

--- a/backend/src/main/kotlin/com/example/routes/TextFragmentRoutes.kt
+++ b/backend/src/main/kotlin/com/example/routes/TextFragmentRoutes.kt
@@ -1,0 +1,8 @@
+package com.example.routes
+
+import com.example.service.TextFragmentService
+import io.ktor.server.routing.Route
+
+fun Route.textFragmentRoutes(textFragmentService: TextFragmentService) {
+
+}

--- a/backend/src/main/kotlin/com/example/routes/TextRoutes.kt
+++ b/backend/src/main/kotlin/com/example/routes/TextRoutes.kt
@@ -15,6 +15,11 @@ fun Route.textRoutes(textService: TextService) {
         call.respondText("Text added successfully", status = HttpStatusCode.Created)
     }
 
+    get("/texts") {
+        val texts = textService.getAllTexts()
+        call.respondText(texts.toString(), status = HttpStatusCode.OK)
+    }
+
     get("/texts/{id}") {
         val id = call.parameters["id"]?.toIntOrNull()
         if (id == null) {

--- a/backend/src/main/kotlin/com/example/routes/TextRoutes.kt
+++ b/backend/src/main/kotlin/com/example/routes/TextRoutes.kt
@@ -8,7 +8,6 @@ import io.ktor.server.response.respondText
 import io.ktor.server.routing.*
 
 fun Route.textRoutes(textService: TextService) {
-
     post("/texts") {
         val text = call.receive<Text>()
         textService.addText(text)
@@ -26,7 +25,6 @@ fun Route.textRoutes(textService: TextService) {
             call.respondText("Invalid ID", status = HttpStatusCode.BadRequest)
             return@get
         }
-
         val text = textService.getTextById(id)
         if (text != null) {
             call.respondText(text.toString(), status = HttpStatusCode.OK)

--- a/backend/src/main/kotlin/com/example/routes/TextRoutes.kt
+++ b/backend/src/main/kotlin/com/example/routes/TextRoutes.kt
@@ -21,10 +21,6 @@ fun Route.textRoutes(textService: TextService) {
 
     get("/texts/{id}") {
         val id = call.parameters["id"]?.toIntOrNull()
-        if (id == null || id <= 0) {
-            call.respondText("Invalid ID", status = HttpStatusCode.BadRequest)
-            return@get
-        }
         val text = textService.getTextById(id)
         if (text != null) {
             call.respondText(text.toString(), status = HttpStatusCode.OK)
@@ -35,10 +31,6 @@ fun Route.textRoutes(textService: TextService) {
 
     put("/texts/{id}") {
         val id = call.parameters["id"]?.toIntOrNull()
-        if (id == null || id <= 0) {
-            call.respondText("Invalid ID", status = HttpStatusCode.BadRequest)
-            return@put
-        }
         val updatedText = call.receive<Text>()
         if (textService.updateText(updatedText.copy(id = id))) {
             call.respondText("Text updated successfully", status = HttpStatusCode.OK)
@@ -50,10 +42,6 @@ fun Route.textRoutes(textService: TextService) {
 
     delete("/texts/{id}") {
         val id = call.parameters["id"]?.toIntOrNull()
-        if (id == null || id <= 0) {
-            call.respondText("Invalid ID", status = HttpStatusCode.BadRequest)
-            return@delete
-        }
         if (textService.deleteTextById(id)) {
             call.respondText("Text deleted successfully", status = HttpStatusCode.OK)
         } else {

--- a/backend/src/main/kotlin/com/example/routes/TextRoutes.kt
+++ b/backend/src/main/kotlin/com/example/routes/TextRoutes.kt
@@ -22,7 +22,7 @@ fun Route.textRoutes(textService: TextService) {
 
     get("/texts/{id}") {
         val id = call.parameters["id"]?.toIntOrNull()
-        if (id == null) {
+        if (id == null || id <= 0) {
             call.respondText("Invalid ID", status = HttpStatusCode.BadRequest)
             return@get
         }
@@ -37,7 +37,7 @@ fun Route.textRoutes(textService: TextService) {
 
     put("/texts/{id}") {
         val id = call.parameters["id"]?.toIntOrNull()
-        if (id == null) {
+        if (id == null || id <= 0) {
             call.respondText("Invalid ID", status = HttpStatusCode.BadRequest)
             return@put
         }
@@ -52,7 +52,7 @@ fun Route.textRoutes(textService: TextService) {
 
     delete("/texts/{id}") {
         val id = call.parameters["id"]?.toIntOrNull()
-        if (id == null) {
+        if (id == null || id <= 0) {
             call.respondText("Invalid ID", status = HttpStatusCode.BadRequest)
             return@delete
         }

--- a/backend/src/main/kotlin/com/example/routes/TextRoutes.kt
+++ b/backend/src/main/kotlin/com/example/routes/TextRoutes.kt
@@ -37,8 +37,12 @@ fun Route.textRoutes(textService: TextService) {
             return@put
         }
         val updatedText = call.receive<Text>()
-        textService.updateText(updatedText.copy(id = id))
-        call.respondText("Text updated successfully", status = HttpStatusCode.OK)
+        if (textService.updateText(updatedText.copy(id = id))) {
+            call.respondText("Text updated successfully", status = HttpStatusCode.OK)
+        } else {
+            call.respondText("Text not modified", status = HttpStatusCode.NotModified)
+        }
+
     }
 
     delete("/texts/{id}") {
@@ -47,7 +51,10 @@ fun Route.textRoutes(textService: TextService) {
             call.respondText("Invalid ID", status = HttpStatusCode.BadRequest)
             return@delete
         }
-        textService.deleteTextById(id)
-        call.respondText("Text deleted successfully", status = HttpStatusCode.OK)
+        if (textService.deleteTextById(id)) {
+            call.respondText("Text deleted successfully", status = HttpStatusCode.OK)
+        } else {
+            call.respondText("Text not deleted", status = HttpStatusCode.NotModified)
+        }
     }
 }

--- a/backend/src/main/kotlin/com/example/routes/UserRoutes.kt
+++ b/backend/src/main/kotlin/com/example/routes/UserRoutes.kt
@@ -1,6 +1,8 @@
 package com.example.routes
 
 import com.example.service.UserService
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
@@ -9,18 +11,18 @@ import io.ktor.server.routing.put
 
 fun Route.userRoutes(userService: UserService) {
     post("/users") {
-        TODO("Not yet implemented")
+        call.respondText("Not yet implemented", status = HttpStatusCode.NotImplemented)
     }
 
     get("/users/{id}") {
-        TODO("Not yet implemented")
+        call.respondText("Not yet implemented", status = HttpStatusCode.NotImplemented)
     }
 
     put("/users/{id}") {
-        TODO("Not yet implemented")
+        call.respondText("Not yet implemented", status = HttpStatusCode.NotImplemented)
     }
 
     delete("/users/{id}") {
-        TODO("Not yet implemented")
+        call.respondText("Not yet implemented", status = HttpStatusCode.NotImplemented)
     }
 }

--- a/backend/src/main/kotlin/com/example/service/TextFragmentService.kt
+++ b/backend/src/main/kotlin/com/example/service/TextFragmentService.kt
@@ -3,9 +3,9 @@ package com.example.service
 import com.example.model.TextFragment
 
 interface TextFragmentService {
-    suspend fun getTextFragmentById(id: Int): TextFragment?
+    suspend fun getTextFragmentById(id: Int?): TextFragment?
     suspend fun addTextFragment(textFragment: TextFragment)
     suspend fun updateTextFragment(textFragment: TextFragment): Boolean
-    suspend fun deleteTextFragmentById(id: Int): Boolean
+    suspend fun deleteTextFragmentById(id: Int?): Boolean
     suspend fun getAllTextFragments(): List<TextFragment>
 }

--- a/backend/src/main/kotlin/com/example/service/TextFragmentService.kt
+++ b/backend/src/main/kotlin/com/example/service/TextFragmentService.kt
@@ -5,7 +5,7 @@ import com.example.model.TextFragment
 interface TextFragmentService {
     suspend fun getTextFragmentById(id: Int): TextFragment?
     suspend fun addTextFragment(textFragment: TextFragment)
-    suspend fun updateTextFragment(textFragment: TextFragment)
-    suspend fun deleteTextFragmentById(id: Int)
+    suspend fun updateTextFragment(textFragment: TextFragment): Boolean
+    suspend fun deleteTextFragmentById(id: Int): Boolean
     suspend fun getAllTextFragments(): List<TextFragment>
 }

--- a/backend/src/main/kotlin/com/example/service/TextFragmentServiceImpl.kt
+++ b/backend/src/main/kotlin/com/example/service/TextFragmentServiceImpl.kt
@@ -2,7 +2,8 @@ package com.example.service
 
 import com.example.model.TextFragment
 import com.example.repository.TextFragmentRepository
-import java.time.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
 
 class TextFragmentServiceImpl(private val fragmentRepository: TextFragmentRepository) : TextFragmentService {
     override suspend fun getTextFragmentById(id: Int): TextFragment? {
@@ -33,7 +34,7 @@ class TextFragmentServiceImpl(private val fragmentRepository: TextFragmentReposi
 
 fun TextFragment.canBeParsedToLocalDateTime(): Boolean {
     return try {
-        createdAt?.let { LocalDateTime.parse(it.toString()) }
+        createdAt?.atStartOfDayIn(TimeZone.currentSystemDefault())
         true
     } catch (_: Exception) {
         false

--- a/backend/src/main/kotlin/com/example/service/TextFragmentServiceImpl.kt
+++ b/backend/src/main/kotlin/com/example/service/TextFragmentServiceImpl.kt
@@ -6,7 +6,8 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
 
 class TextFragmentServiceImpl(private val fragmentRepository: TextFragmentRepository) : TextFragmentService {
-    override suspend fun getTextFragmentById(id: Int): TextFragment? {
+    override suspend fun getTextFragmentById(id: Int?): TextFragment? {
+        require(id != null) { "ID cannot be empty" }
         require(id >= 0) { "ID cannot be negative" }
         return fragmentRepository.getTextFragmentById(id)
             ?: throw NoSuchElementException("No fragment found with id $id")
@@ -24,7 +25,8 @@ class TextFragmentServiceImpl(private val fragmentRepository: TextFragmentReposi
         return fragmentRepository.updateTextFragment(textFragment) != 0
     }
 
-    override suspend fun deleteTextFragmentById(id: Int): Boolean {
+    override suspend fun deleteTextFragmentById(id: Int?): Boolean {
+        require(id != null) { "ID cannot be empty" }
         require(id >= 0) { "ID cannot be negative" }
         return fragmentRepository.deleteTextFragmentById(id) != 0
     }

--- a/backend/src/main/kotlin/com/example/service/TextFragmentServiceImpl.kt
+++ b/backend/src/main/kotlin/com/example/service/TextFragmentServiceImpl.kt
@@ -18,15 +18,15 @@ class TextFragmentServiceImpl(private val fragmentRepository: TextFragmentReposi
         fragmentRepository.addTextFragment(textFragment)
     }
 
-    override suspend fun updateTextFragment(textFragment: TextFragment) {
+    override suspend fun updateTextFragment(textFragment: TextFragment): Boolean {
         require(textFragment.contentXML.isNotBlank() && textFragment.textId >= 0) { "Fragment cannot be empty" }
         require(textFragment.canBeParsedToLocalDateTime()) { "Field 'createdAt': '${textFragment.createdAt}' cannot be parsed to LocalDateTime" }
-        fragmentRepository.updateTextFragment(textFragment)
+        return fragmentRepository.updateTextFragment(textFragment) != 0
     }
 
-    override suspend fun deleteTextFragmentById(id: Int) {
+    override suspend fun deleteTextFragmentById(id: Int): Boolean {
         require(id >= 0) { "ID cannot be negative" }
-        fragmentRepository.deleteTextFragmentById(id)
+        return fragmentRepository.deleteTextFragmentById(id) != 0
     }
 
     override suspend fun getAllTextFragments(): List<TextFragment> = fragmentRepository.getAllTextFragments()

--- a/backend/src/main/kotlin/com/example/service/TextService.kt
+++ b/backend/src/main/kotlin/com/example/service/TextService.kt
@@ -3,9 +3,9 @@ package com.example.service
 import com.example.model.Text
 
 interface TextService {
-    suspend fun getTextById(id: Int): Text?
+    suspend fun getTextById(id: Int?): Text?
     suspend fun addText(text: Text)
     suspend fun updateText(text: Text): Boolean
-    suspend fun deleteTextById(id: Int): Boolean
+    suspend fun deleteTextById(id: Int?): Boolean
     suspend fun getAllTexts(): List<Text>
 }

--- a/backend/src/main/kotlin/com/example/service/TextService.kt
+++ b/backend/src/main/kotlin/com/example/service/TextService.kt
@@ -5,7 +5,7 @@ import com.example.model.Text
 interface TextService {
     suspend fun getTextById(id: Int): Text?
     suspend fun addText(text: Text)
-    suspend fun updateText(text: Text)
-    suspend fun deleteTextById(id: Int)
+    suspend fun updateText(text: Text): Boolean
+    suspend fun deleteTextById(id: Int): Boolean
     suspend fun getAllTexts(): List<Text>
 }

--- a/backend/src/main/kotlin/com/example/service/TextServiceImpl.kt
+++ b/backend/src/main/kotlin/com/example/service/TextServiceImpl.kt
@@ -2,7 +2,8 @@ package com.example.service
 
 import com.example.model.Text
 import com.example.repository.TextRepository
-import java.time.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
 
 class TextServiceImpl(private val textRepository: TextRepository) : TextService {
 
@@ -13,7 +14,7 @@ class TextServiceImpl(private val textRepository: TextRepository) : TextService 
 
     override suspend fun addText(text: Text) {
         require(text.pureText.isNotBlank() && text.lineIds.isNotEmpty()) { "Text cannot be empty" }
-        require(text.canBeParsedToLocalDateTime()){ "Field 'createdAt': '${text.createdAt}' cannot be parsed to LocalDateTime" }
+        require(text.canBeParsedToLocalDateTime()) { "Field 'createdAt': '${text.createdAt}' cannot be parsed to LocalDateTime" }
         textRepository.addText(text)
     }
 
@@ -34,9 +35,9 @@ class TextServiceImpl(private val textRepository: TextRepository) : TextService 
 
 fun Text.canBeParsedToLocalDateTime(): Boolean {
     return try {
-        createdAt?.let { LocalDateTime.parse(it.toString()) }
+        createdAt?.atStartOfDayIn(TimeZone.currentSystemDefault())
         true
-    } catch (_: Exception){
+    } catch (_: Exception) {
         false
     }
 }

--- a/backend/src/main/kotlin/com/example/service/TextServiceImpl.kt
+++ b/backend/src/main/kotlin/com/example/service/TextServiceImpl.kt
@@ -7,7 +7,8 @@ import kotlinx.datetime.atStartOfDayIn
 
 class TextServiceImpl(private val textRepository: TextRepository) : TextService {
 
-    override suspend fun getTextById(id: Int): Text? {
+    override suspend fun getTextById(id: Int?): Text? {
+        require(id != null) { "ID cannot be empty" }
         require(id >= 0) { "ID cannot be negative" }
         return textRepository.getTextById(id) ?: throw NoSuchElementException("No text found with id $id")
     }
@@ -24,7 +25,8 @@ class TextServiceImpl(private val textRepository: TextRepository) : TextService 
         return textRepository.updateText(text) != 0
     }
 
-    override suspend fun deleteTextById(id: Int): Boolean {
+    override suspend fun deleteTextById(id: Int?): Boolean {
+        require(id != null) { "ID cannot be empty" }
         require(id >= 0) { "ID cannot be negative" }
         return textRepository.deleteTextById(id) != 0
     }

--- a/backend/src/main/kotlin/com/example/service/TextServiceImpl.kt
+++ b/backend/src/main/kotlin/com/example/service/TextServiceImpl.kt
@@ -17,15 +17,15 @@ class TextServiceImpl(private val textRepository: TextRepository) : TextService 
         textRepository.addText(text)
     }
 
-    override suspend fun updateText(text: Text) {
+    override suspend fun updateText(text: Text): Boolean {
         require(text.pureText.isNotBlank() && text.lineIds.isNotEmpty()) { "Text cannot be empty" }
         require(text.canBeParsedToLocalDateTime()) { "Field 'createdAt': '${text.createdAt}' cannot be parsed to LocalDateTime" }
-        textRepository.updateText(text)
+        return textRepository.updateText(text) != 0
     }
 
-    override suspend fun deleteTextById(id: Int) {
+    override suspend fun deleteTextById(id: Int): Boolean {
         require(id >= 0) { "ID cannot be negative" }
-        textRepository.deleteTextById(id)
+        return textRepository.deleteTextById(id) != 0
     }
 
     override suspend fun getAllTexts(): List<Text> = textRepository.getAllTexts()

--- a/backend/src/main/kotlin/com/example/service/UserService.kt
+++ b/backend/src/main/kotlin/com/example/service/UserService.kt
@@ -5,7 +5,7 @@ import com.example.model.ExposedUser
 interface UserService {
     suspend fun getAllUsers(): List<ExposedUser>
     suspend fun getUserById(id: Int): ExposedUser?
-    suspend fun addUser(user: ExposedUser)
+    suspend fun createUser(user: ExposedUser)
     suspend fun updateUser(id: Int, user: ExposedUser): Boolean
     suspend fun deleteUser(id: Int): Boolean
 }

--- a/backend/src/main/kotlin/com/example/service/UsersServiceImpl.kt
+++ b/backend/src/main/kotlin/com/example/service/UsersServiceImpl.kt
@@ -12,7 +12,7 @@ class UserServiceImpl(private val userRepository: UserRepository) : UserService 
         TODO("Not yet implemented")
     }
 
-    override suspend fun addUser(user: ExposedUser) {
+    override suspend fun createUser(user: ExposedUser) {
         TODO("Not yet implemented")
     }
 

--- a/backend/src/main/resources/application-test.conf
+++ b/backend/src/main/resources/application-test.conf
@@ -3,10 +3,4 @@ ktor {
     port = 8080
     host = "0.0.0.0"
   }
-  db {
-    url = "jdbc:postgresql://localhost:5432/tangut_db"
-    user = "tangut"
-    password = "qwerty123"
-    driver = "org.postgresql.Driver"
-  }
 }

--- a/backend/src/main/resources/application-test.conf
+++ b/backend/src/main/resources/application-test.conf
@@ -1,0 +1,12 @@
+ktor {
+  deployment {
+    port = 8080
+    host = "0.0.0.0"
+  }
+  db {
+    url = "jdbc:postgresql://localhost:5432/tangut_db"
+    user = "tangut"
+    password = "qwerty123"
+    driver = "org.postgresql.Driver"
+  }
+}

--- a/backend/src/test/kotlin/com/example/ApplicationTest.kt
+++ b/backend/src/test/kotlin/com/example/ApplicationTest.kt
@@ -1,15 +1,4 @@
 package com.example
 
-import com.example.routes.MainPageRoutesTest
-import kotlin.test.Test
-
-open class ApplicationTest {
-
-    @Test
-    fun runAllTests() {
-        MainPageRoutesTest().apply{
-            `test GET main page returns OK`()
-        }
-    }
-}
+class ApplicationTest
 

--- a/backend/src/test/kotlin/com/example/ApplicationTest.kt
+++ b/backend/src/test/kotlin/com/example/ApplicationTest.kt
@@ -1,21 +1,12 @@
 package com.example
 
-import com.example.routes.configureRouting
-import io.ktor.client.request.*
-import io.ktor.client.statement.*
-import io.ktor.http.*
-import io.ktor.server.testing.*
-import kotlin.test.*
+import kotlin.test.Test
 
-class ApplicationTest {
+open class ApplicationTest {
+
     @Test
-    fun testRoot() = testApplication {
-        application {
-            configureRouting()
-        }
-        client.get("/").apply {
-            assertEquals(HttpStatusCode.OK, status)
-            assertEquals("Hello World!", bodyAsText())
-        }
+    fun runAllTests() {
+
     }
 }
+

--- a/backend/src/test/kotlin/com/example/ApplicationTest.kt
+++ b/backend/src/test/kotlin/com/example/ApplicationTest.kt
@@ -1,12 +1,15 @@
 package com.example
 
+import com.example.routes.MainPageRoutesTest
 import kotlin.test.Test
 
 open class ApplicationTest {
 
     @Test
     fun runAllTests() {
-
+        MainPageRoutesTest().apply{
+            `test GET main page returns OK`()
+        }
     }
 }
 

--- a/backend/src/test/kotlin/com/example/ApplicationTest.kt
+++ b/backend/src/test/kotlin/com/example/ApplicationTest.kt
@@ -1,4 +1,0 @@
-package com.example
-
-class ApplicationTest
-

--- a/backend/src/test/kotlin/com/example/helpers/TestExtensions.kt
+++ b/backend/src/test/kotlin/com/example/helpers/TestExtensions.kt
@@ -3,7 +3,7 @@ package com.example.helpers
 import com.example.config.initDatabase
 import com.example.repository.TextRepositoryImpl
 import com.example.repository.UserRepositoryImpl
-import com.example.routes.configureRouting
+import com.example.config.configureRouting
 import com.example.service.TextServiceImpl
 import com.example.service.UserServiceImpl
 import io.ktor.server.application.Application

--- a/backend/src/test/kotlin/com/example/helpers/TestExtensions.kt
+++ b/backend/src/test/kotlin/com/example/helpers/TestExtensions.kt
@@ -14,6 +14,11 @@ import io.ktor.server.config.ApplicationConfig
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.mockk.coEvery
 import io.mockk.mockk
+import org.jetbrains.exposed.sql.Database
+
+fun getH2Database(): Database {
+    return Database.connect("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;", driver = "org.h2.Driver")
+}
 
 fun ApplicationTestBuilder.setupApp(defaultText: Text? = null) {
     environment {

--- a/backend/src/test/kotlin/com/example/helpers/TestExtensions.kt
+++ b/backend/src/test/kotlin/com/example/helpers/TestExtensions.kt
@@ -1,0 +1,26 @@
+package com.example.helpers
+
+import com.example.config.initDatabase
+import com.example.repository.TextRepositoryImpl
+import com.example.repository.UserRepositoryImpl
+import com.example.routes.configureRouting
+import com.example.service.TextServiceImpl
+import com.example.service.UserServiceImpl
+import io.ktor.server.config.ApplicationConfig
+import io.ktor.server.testing.ApplicationTestBuilder
+
+fun ApplicationTestBuilder.setupApp() {
+    environment {
+        config = ApplicationConfig("application-test.conf")
+    }
+    application {
+        val mockDatabase = initDatabase(environment.config)
+        val userRepository = UserRepositoryImpl(mockDatabase)
+        val userService = UserServiceImpl(userRepository)
+
+        val textRepository = TextRepositoryImpl(mockDatabase)
+        val textService = TextServiceImpl(textRepository)
+
+        configureRouting(userService, textService)
+    }
+}

--- a/backend/src/test/kotlin/com/example/helpers/TestExtensions.kt
+++ b/backend/src/test/kotlin/com/example/helpers/TestExtensions.kt
@@ -1,11 +1,14 @@
 package com.example.helpers
 
-import com.example.config.initDatabase
-import com.example.repository.TextRepositoryImpl
-import com.example.repository.UserRepositoryImpl
+import com.example.config.configureExceptionHandling
+import com.example.config.configureHTTP
+import com.example.config.configureMonitoring
 import com.example.config.configureRouting
-import com.example.service.TextServiceImpl
-import com.example.service.UserServiceImpl
+import com.example.config.configureSecurity
+import com.example.config.configureSerialization
+import com.example.model.Text
+import com.example.service.TextService
+import com.example.service.UserService
 import io.ktor.server.application.Application
 import io.ktor.server.config.ApplicationConfig
 import io.ktor.server.testing.ApplicationTestBuilder
@@ -16,19 +19,21 @@ fun ApplicationTestBuilder.setupApp() {
         config = ApplicationConfig("application-test.conf")
     }
     application {
-        module()
+        testModule()
     }
 }
 
-fun Application.module() {
     val mockDatabase = initDatabase(environment.config)
 
     val userRepository = UserRepositoryImpl(mockDatabase)
     val userService = UserServiceImpl(userRepository)
-
-    val textRepository = TextRepositoryImpl(mockDatabase)
-    val textService = TextServiceImpl(textRepository)
+fun Application.testModule() {
 
     configureRouting(userService, textService)
+    configureExceptionHandling()
+    configureSerialization()
+    configureMonitoring()
+    configureHTTP()
+    configureSecurity()
 }
 

--- a/backend/src/test/kotlin/com/example/helpers/TestExtensions.kt
+++ b/backend/src/test/kotlin/com/example/helpers/TestExtensions.kt
@@ -6,21 +6,29 @@ import com.example.repository.UserRepositoryImpl
 import com.example.routes.configureRouting
 import com.example.service.TextServiceImpl
 import com.example.service.UserServiceImpl
+import io.ktor.server.application.Application
 import io.ktor.server.config.ApplicationConfig
 import io.ktor.server.testing.ApplicationTestBuilder
 
 fun ApplicationTestBuilder.setupApp() {
+
     environment {
         config = ApplicationConfig("application-test.conf")
     }
     application {
-        val mockDatabase = initDatabase(environment.config)
-        val userRepository = UserRepositoryImpl(mockDatabase)
-        val userService = UserServiceImpl(userRepository)
-
-        val textRepository = TextRepositoryImpl(mockDatabase)
-        val textService = TextServiceImpl(textRepository)
-
-        configureRouting(userService, textService)
+        module()
     }
 }
+
+fun Application.module() {
+    val mockDatabase = initDatabase(environment.config)
+
+    val userRepository = UserRepositoryImpl(mockDatabase)
+    val userService = UserServiceImpl(userRepository)
+
+    val textRepository = TextRepositoryImpl(mockDatabase)
+    val textService = TextServiceImpl(textRepository)
+
+    configureRouting(userService, textService)
+}
+

--- a/backend/src/test/kotlin/com/example/reposiotries/TextFragmentRepositoryTest.kt
+++ b/backend/src/test/kotlin/com/example/reposiotries/TextFragmentRepositoryTest.kt
@@ -1,11 +1,11 @@
 package com.example.reposiotries
 
+import com.example.helpers.getH2Database
 import com.example.model.TextFragment
 import com.example.model.TextFragments
 import com.example.model.Texts
 import com.example.repository.TextFragmentRepositoryImpl
 import kotlinx.coroutines.runBlocking
-import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.StdOutSqlLogger
@@ -19,7 +19,7 @@ import kotlin.test.*
 
 class TextFragmentRepositoryTest {
     private lateinit var repository: TextFragmentRepositoryImpl
-    private val db = Database.connect("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;", driver = "org.h2.Driver")
+    private val db = getH2Database()
 
     private var textId by Delegates.notNull<Int>()
     private val sampleFragment = TextFragment(null, 0, 1, "Test", "Test", null)

--- a/backend/src/test/kotlin/com/example/reposiotries/TextFragmentRepositoryTest.kt
+++ b/backend/src/test/kotlin/com/example/reposiotries/TextFragmentRepositoryTest.kt
@@ -1,0 +1,98 @@
+package com.example.reposiotries
+
+import com.example.model.TextFragment
+import com.example.model.TextFragments
+import com.example.model.Texts
+import com.example.repository.TextFragmentRepositoryImpl
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.StdOutSqlLogger
+import org.jetbrains.exposed.sql.addLogger
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.transactions.transaction
+import java.time.LocalDateTime
+import kotlin.properties.Delegates
+import kotlin.test.*
+
+class TextFragmentRepositoryTest {
+    private lateinit var repository: TextFragmentRepositoryImpl
+    private val db = Database.connect("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;", driver = "org.h2.Driver")
+
+    private var textId by Delegates.notNull<Int>()
+    private val sampleFragment = TextFragment(null, 0, 1, "Test", "Test", null)
+
+    @BeforeTest
+    fun setup() {
+        transaction(db) {
+            addLogger(StdOutSqlLogger)
+            SchemaUtils.drop(TextFragments)
+            SchemaUtils.drop(Texts)
+            SchemaUtils.create(Texts, TextFragments)
+
+            textId = Texts.insert {
+                it[comment] = "Text"
+                it[lineIds] = listOf(1).toString()
+                it[pureText] = "Text"
+                it[createdAt] = LocalDateTime.now()
+            } get Texts.id
+        }
+        repository = TextFragmentRepositoryImpl(db)
+    }
+
+    @Test
+    fun `addTextFragment inserts and returns new fragment ID`() = runBlocking {
+        val fragmentId = repository.addTextFragment(sampleFragment.copy(textId = textId))
+        assertNotNull(fragmentId)
+
+        val retrieved = repository.getTextFragmentById(fragmentId)
+        assertNotNull(retrieved)
+        assertEquals(sampleFragment.contentXML, retrieved.contentXML)
+        assertEquals(sampleFragment.commentXML, retrieved.commentXML)
+    }
+
+    @Test
+    fun `getTextFragmentById returns correct fragment`() = runBlocking {
+        val fragmentId = repository.addTextFragment(sampleFragment.copy(textId = textId))
+        val fragment = repository.getTextFragmentById(fragmentId)
+
+        assertNotNull(fragment)
+        assertEquals(sampleFragment.contentXML, fragment.contentXML)
+        assertEquals(sampleFragment.lineNumber, fragment.lineNumber)
+    }
+
+    @Test
+    fun `updateTextFragment modifies existing fragment`() = runBlocking {
+        val fragmentId = repository.addTextFragment(sampleFragment.copy(textId = textId))
+        val updatedFragment = sampleFragment.copy(
+            id = fragmentId, textId = textId, contentXML = "Updated"
+        )
+
+        repository.updateTextFragment(updatedFragment)
+        val retrieved = repository.getTextFragmentById(fragmentId)
+
+        assertNotNull(retrieved)
+        assertEquals(updatedFragment.contentXML, retrieved.contentXML)
+        assertEquals(updatedFragment.commentXML, retrieved.commentXML)
+    }
+
+    @Test
+    fun `deleteTextFragmentById removes fragment`() = runBlocking {
+        val fragmentId = repository.addTextFragment(sampleFragment.copy(textId = textId))
+        repository.deleteTextFragmentById(fragmentId)
+        val deletedFragment = repository.getTextFragmentById(fragmentId)
+        assertNull(deletedFragment)
+    }
+
+    @Test
+    fun `cascade delete removes fragments when related text is deleted`() = runBlocking {
+        val fragmentId = repository.addTextFragment(sampleFragment.copy(textId = textId))
+        transaction(db) {
+            Texts.deleteWhere { id eq textId }
+        }
+        val orphanedFragment = repository.getTextFragmentById(fragmentId)
+        assertNull(orphanedFragment)
+    }
+}

--- a/backend/src/test/kotlin/com/example/reposiotries/TextRepositoryTest.kt
+++ b/backend/src/test/kotlin/com/example/reposiotries/TextRepositoryTest.kt
@@ -1,12 +1,12 @@
 package com.example.reposiotries
 
+import com.example.helpers.getH2Database
 import com.example.model.Text
 import com.example.model.TextFragments
 import com.example.model.Texts
 import com.example.repository.TextRepository
 import com.example.repository.TextRepositoryImpl
 import kotlinx.coroutines.runBlocking
-import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.StdOutSqlLogger
 import org.jetbrains.exposed.sql.addLogger
@@ -16,7 +16,7 @@ import kotlin.test.*
 
 class TextRepositoryTest {
     private lateinit var repository: TextRepository
-    private val db = Database.connect("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;", driver = "org.h2.Driver")
+    private val db = getH2Database()
 
     private val sampleText = Text(1, "Text", listOf(1), "Text", null)
 

--- a/backend/src/test/kotlin/com/example/reposiotries/TextRepositoryTest.kt
+++ b/backend/src/test/kotlin/com/example/reposiotries/TextRepositoryTest.kt
@@ -1,0 +1,65 @@
+package com.example.reposiotries
+
+import com.example.model.Text
+import com.example.model.TextFragments
+import com.example.model.Texts
+import com.example.repository.TextRepository
+import com.example.repository.TextRepositoryImpl
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.StdOutSqlLogger
+import org.jetbrains.exposed.sql.addLogger
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.transactions.transaction
+import kotlin.test.*
+
+class TextRepositoryTest {
+    private lateinit var repository: TextRepository
+    private val db = Database.connect("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;", driver = "org.h2.Driver")
+
+    private val sampleText = Text(1, "Text", listOf(1), "Text", null)
+
+    @BeforeTest
+    fun setup() {
+        transaction {
+            addLogger(StdOutSqlLogger)
+            SchemaUtils.drop(TextFragments)
+            SchemaUtils.drop(Texts)
+            SchemaUtils.create(Texts)
+            Texts.insert {
+                it[comment] = sampleText.comment
+                it[createdAt] = null
+                it[lineIds] = sampleText.lineIds.toString()
+                it[pureText] = sampleText.pureText
+            }
+        }
+        repository = TextRepositoryImpl(db)
+    }
+
+    @Test
+    fun `get text by valid id returns text`(): Unit = runBlocking {
+        assertNotNull(repository.getTextById(1))
+        assertEquals(1, repository.deleteTextById(1))
+    }
+
+    @Test
+    fun `get text by invalid id returns null`() = runBlocking {
+        assertNull(repository.getTextById(22222))
+    }
+
+    @Test
+    fun `add valid text returns generated id`(): Unit = runBlocking {
+        assertNotNull(repository.addText(sampleText))
+    }
+
+    @Test
+    fun `update existing text`() = runBlocking {
+        assertEquals(1, repository.updateText(sampleText))
+    }
+
+    @Test
+    fun `delete text by invalid id does nothing`() = runBlocking {
+        assertEquals(0, repository.deleteTextById(2222))
+    }
+}

--- a/backend/src/test/kotlin/com/example/reposiotries/UserRepositoryTest.kt
+++ b/backend/src/test/kotlin/com/example/reposiotries/UserRepositoryTest.kt
@@ -16,7 +16,7 @@ class UserRepositoryTest {
     private val EXCEPTION_MESSAGE: String = "An operation is not implemented: Not yet implemented"
 
     @BeforeTest
-    fun before() {
+    fun setup() {
         var database = mockk<Database>(relaxed = true)
         repository = UserRepositoryImpl(database)
     }
@@ -26,14 +26,6 @@ class UserRepositoryTest {
         var user = ExposedUser("", 0)
         var exception = assertFailsWith<NotImplementedError> {
             repository.createUser(user)
-        }
-        assertEquals(EXCEPTION_MESSAGE, exception.message)
-    }
-
-    @Test
-    fun `test readUser throws NotImplementedError`() = runBlocking {
-        var exception = assertFailsWith<NotImplementedError> {
-            repository.readUser(1)
         }
         assertEquals(EXCEPTION_MESSAGE, exception.message)
     }

--- a/backend/src/test/kotlin/com/example/reposiotries/UserRepositoryTest.kt
+++ b/backend/src/test/kotlin/com/example/reposiotries/UserRepositoryTest.kt
@@ -1,0 +1,73 @@
+package com.example.reposiotries
+
+import com.example.model.ExposedUser
+import com.example.repository.UserRepository
+import com.example.repository.UserRepositoryImpl
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.sql.Database
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class UserRepositoryTest {
+    private lateinit var repository: UserRepository
+    private val EXCEPTION_MESSAGE: String = "An operation is not implemented: Not yet implemented"
+
+    @BeforeTest
+    fun before() {
+        var database = mockk<Database>(relaxed = true)
+        repository = UserRepositoryImpl(database)
+    }
+
+    @Test
+    fun `test createUser throws NotImplementedError`() = runBlocking {
+        var user = ExposedUser("", 0)
+        var exception = assertFailsWith<NotImplementedError> {
+            repository.createUser(user)
+        }
+        assertEquals(EXCEPTION_MESSAGE, exception.message)
+    }
+
+    @Test
+    fun `test readUser throws NotImplementedError`() = runBlocking {
+        var exception = assertFailsWith<NotImplementedError> {
+            repository.readUser(1)
+        }
+        assertEquals(EXCEPTION_MESSAGE, exception.message)
+    }
+
+    @Test
+    fun `test updateUser throws NotImplementedError`() = runBlocking {
+        var user = ExposedUser("", 0)
+        var exception = assertFailsWith<NotImplementedError> {
+            repository.updateUser(1, user)
+        }
+        assertEquals(EXCEPTION_MESSAGE, exception.message)
+    }
+
+    @Test
+    fun `test deleteUser throws NotImplementedError`() = runBlocking {
+        var exception = assertFailsWith<NotImplementedError> {
+            repository.deleteUser(1)
+        }
+        assertEquals(EXCEPTION_MESSAGE, exception.message)
+    }
+
+    @Test
+    fun `test getAllUsers throws NotImplementedError`() = runBlocking {
+        var exception = assertFailsWith<NotImplementedError> {
+            repository.getAllUsers()
+        }
+        assertEquals(EXCEPTION_MESSAGE, exception.message)
+    }
+
+    @Test
+    fun `test getUserById throws NotImplementedError`() = runBlocking {
+        var exception = assertFailsWith<NotImplementedError> {
+            repository.getUserById(1)
+        }
+        assertEquals(EXCEPTION_MESSAGE, exception.message)
+    }
+}

--- a/backend/src/test/kotlin/com/example/routes/MainPageRoutesTest.kt
+++ b/backend/src/test/kotlin/com/example/routes/MainPageRoutesTest.kt
@@ -1,0 +1,20 @@
+package com.example.routes
+
+import com.example.helpers.setupApp
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class MainPageRoutesTest() {
+    @Test
+    fun `test GET main page returns OK`() = testApplication {
+        setupApp()
+        val response = client.get("/")
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("Hello World!", response.bodyAsText())
+    }
+}

--- a/backend/src/test/kotlin/com/example/routes/MainPageRoutesTest.kt
+++ b/backend/src/test/kotlin/com/example/routes/MainPageRoutesTest.kt
@@ -1,7 +1,6 @@
 package com.example.routes
 
 import com.example.helpers.setupApp
-import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode

--- a/backend/src/test/kotlin/com/example/routes/TextFragmentRoutesTest.kt
+++ b/backend/src/test/kotlin/com/example/routes/TextFragmentRoutesTest.kt
@@ -1,0 +1,86 @@
+package com.example.routes
+
+import com.example.helpers.setupApp
+import com.example.model.Text
+import com.example.model.TextFragment
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class TextFragmentRoutesTest {
+    private val fragment = TextFragment(1, 1, 1, "", "", null)
+
+    private fun HttpRequestBuilder.jsonRequest(fragment: TextFragment) {
+        contentType(ContentType.Application.Json)
+        setBody(Json.encodeToString(fragment))
+    }
+
+    @Test
+    fun `test POST fragment creates fragment`() = testApplication {
+        setupApp(defaultTextFragment = fragment)
+        val response = client.post("/fragments") {
+            jsonRequest(fragment)
+        }
+        assertEquals(HttpStatusCode.Created, response.status)
+    }
+
+    @Test
+    fun `test GET all texts returns texts`() = testApplication {
+        setupApp(defaultTextFragment = fragment)
+        val response = client.get("/fragments")
+        assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    @Test
+    fun `test GET text returns text`() = testApplication {
+        setupApp(defaultTextFragment = fragment)
+        val response = client.get("/fragments/1")
+        assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    @Test
+    fun `test GET non-existing text returns NotFound`() = testApplication {
+        setupApp(defaultTextFragment = fragment)
+        val response = client.get("/fragments/2") {}
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+
+    @Test
+    fun `test PUT non-existing text returns NotFound`() = testApplication {
+        setupApp(defaultTextFragment = fragment)
+        val response = client.put("/fragments/2") {
+            jsonRequest(fragment)
+        }
+        assertEquals(HttpStatusCode.NotModified, response.status)
+    }
+
+    @Test
+    fun `test PUT text updates text`() = testApplication {
+        setupApp(defaultTextFragment = fragment)
+        val response = client.put("/fragments/1") {
+            jsonRequest(fragment)
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    @Test
+    fun `test DELETE text deletes text`() = testApplication {
+        setupApp(defaultTextFragment = fragment)
+        val response = client.delete("/fragments/1") {
+            jsonRequest(fragment)
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+    }
+}

--- a/backend/src/test/kotlin/com/example/routes/TextRoutesTest.kt
+++ b/backend/src/test/kotlin/com/example/routes/TextRoutesTest.kt
@@ -1,0 +1,110 @@
+package com.example.routes
+
+import com.example.helpers.setupApp
+import com.example.model.Text
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TextRoutesTest {
+    private val text = Text(1, "", listOf(0, 1, 2), "", null)
+
+    private fun HttpRequestBuilder.jsonRequest(text: Text) {
+        contentType(ContentType.Application.Json)
+        setBody(Json.encodeToString(text))
+    }
+
+    @Test
+    fun `test POST texts creates text`() = testApplication {
+        setupApp(defaultText = text)
+        val response = client.post("/texts") {
+            jsonRequest(text)
+        }
+        assertEquals(HttpStatusCode.Created, response.status)
+    }
+
+    @Test
+    fun `test GET all texts returns texts`() = testApplication {
+        setupApp(defaultText = text)
+        val response = client.get("/texts")
+        assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    @Test
+    fun `test GET text returns text`() = testApplication {
+        setupApp(defaultText = text)
+        val response = client.get("/texts/1")
+        assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    @Test
+    fun `test GET text by invalid ID returns BadRequest`() = testApplication {
+        setupApp(defaultText = text)
+        val response = client.get("/texts/-1") {}
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun `test GET non-existing text returns NotFound`() = testApplication {
+        setupApp(defaultText = text)
+        val response = client.get("/texts/2") {}
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+
+    @Test
+    fun `test PUT non-existing text returns NotFound`() = testApplication {
+        setupApp(defaultText = text)
+        val response = client.put("/texts/2") {
+            jsonRequest(text)
+        }
+        assertEquals(HttpStatusCode.NotModified, response.status)
+    }
+
+    @Test
+    fun `test PUT text by invalid ID returns BadRequest`() = testApplication {
+        setupApp(defaultText = text)
+        val response = client.put("/texts/-1") {
+            jsonRequest(text)
+        }
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun `test PUT text updates text`() = testApplication {
+        setupApp(defaultText = text)
+        val response = client.put("/texts/1") {
+            jsonRequest(text)
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    @Test
+    fun `test DELETE text by invalid ID returns BadRequest`() = testApplication {
+        setupApp(defaultText = text)
+        val response = client.delete("/texts/-1") {
+            jsonRequest(text)
+        }
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun `test DELETE text deletes text`() = testApplication {
+        setupApp(defaultText = text)
+        val response = client.delete("/texts/1") {
+            jsonRequest(text)
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+    }
+}

--- a/backend/src/test/kotlin/com/example/routes/UserRoutesTest.kt
+++ b/backend/src/test/kotlin/com/example/routes/UserRoutesTest.kt
@@ -1,0 +1,82 @@
+package com.example.routes
+
+import com.example.helpers.setupApp
+import com.example.model.ExposedUser
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.testing.testApplication
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UserRoutesTest {
+    @Test
+    fun `test POST users returns 404 when not implemented`() = testApplication {
+        setupApp()
+
+        val client = createClient {
+            install(ContentNegotiation) {
+                json()
+            }
+        }
+
+        val response = client.post("/users") {
+            contentType(ContentType.Application.Json)
+            setBody(ExposedUser("Test", 20))
+        }
+        assertEquals(HttpStatusCode.NotImplemented, response.status)
+        assertEquals("Not yet implemented", response.bodyAsText())
+    }
+
+    @Test
+    fun `test GET user returns 404 when not implemented`() = testApplication {
+        setupApp()
+
+        val response = client.get("/users/1")
+        assertEquals(HttpStatusCode.NotImplemented, response.status)
+        assertEquals("Not yet implemented", response.bodyAsText())
+    }
+
+    @Test
+    fun `test PUT user returns 404 when not implemented`() = testApplication {
+        setupApp()
+
+        val client = createClient {
+            install(ContentNegotiation) {
+                json()
+            }
+        }
+
+        val response = client.put("/users/1") {
+            contentType(ContentType.Application.Json)
+            setBody(ExposedUser("Test", 20))
+        }
+        assertEquals(HttpStatusCode.NotImplemented, response.status)
+        assertEquals("Not yet implemented", response.bodyAsText())
+    }
+
+    @Test
+    fun `test DELETE user returns 404 when not implemented`() = testApplication {
+        setupApp()
+
+        val client = createClient {
+            install(ContentNegotiation) {
+                json()
+            }
+        }
+
+        val response = client.delete("/users/1")
+        assertEquals(HttpStatusCode.NotImplemented, response.status)
+        assertEquals("Not yet implemented", response.bodyAsText())
+    }
+
+}
+

--- a/backend/src/test/kotlin/com/example/services/TextFragmentServiceTest.kt
+++ b/backend/src/test/kotlin/com/example/services/TextFragmentServiceTest.kt
@@ -1,0 +1,94 @@
+package com.example.services
+
+import com.example.model.TextFragment
+import com.example.repository.TextFragmentRepository
+import com.example.service.TextFragmentService
+import com.example.service.TextFragmentServiceImpl
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import kotlin.test.*
+import kotlin.test.BeforeTest
+
+class TextFragmentServiceTest {
+    private lateinit var service: TextFragmentService
+    private val repository = mockk<TextFragmentRepository>(relaxed = true)
+
+    private val validFragment = TextFragment(1, 1, 1, "Text", "Text", null)
+    private val invalidFragment = TextFragment(1, -1, 1, "", "", null)
+
+    @BeforeTest
+    fun setup() {
+        service = TextFragmentServiceImpl(repository)
+
+        coEvery { repository.getTextFragmentById(1) } returns validFragment
+        coEvery { repository.getTextFragmentById(2) } returns null
+        coEvery { repository.addTextFragment(validFragment) } returns 1
+        coEvery { repository.updateTextFragment(validFragment) } returns 1
+        coEvery { repository.deleteTextFragmentById(1) } returns 1
+        coEvery { repository.getAllTextFragments() } returns listOf(validFragment)
+    }
+
+    @Test
+    fun `get text fragment by valid id returns text fragment`() = runBlocking {
+        val result = service.getTextFragmentById(1)
+        assertEquals(validFragment, result)
+    }
+
+    @Test
+    fun `get text fragment by invalid id throws exception`() = runBlocking {
+        val exception = assertFailsWith<NoSuchElementException> {
+            service.getTextFragmentById(2)
+        }
+        assertEquals("No fragment found with id 2", exception.message)
+    }
+
+    @Test
+    fun `add valid text fragment`() = runBlocking {
+        assertDoesNotThrow { service.addTextFragment(validFragment) }
+        coVerify { repository.addTextFragment(validFragment) }
+    }
+
+    @Test
+    fun `add invalid text fragment throws exception`() = runBlocking {
+        val exception = assertFailsWith<IllegalArgumentException> {
+            service.addTextFragment(invalidFragment)
+        }
+        assertTrue(exception.message!!.contains("Fragment cannot be empty"))
+    }
+
+    @Test
+    fun `update valid text fragment`() = runBlocking {
+        assertTrue(service.updateTextFragment(validFragment))
+    }
+
+    @Test
+    fun `update invalid text fragment throws exception`() = runBlocking {
+        val exception = assertFailsWith<IllegalArgumentException> {
+            service.updateTextFragment(invalidFragment)
+        }
+        assertTrue(exception.message!!.contains("Fragment cannot be empty"))
+    }
+
+    @Test
+    fun `delete text fragment by valid id`() = runBlocking {
+        assertTrue(service.deleteTextFragmentById(1))
+    }
+
+    @Test
+    fun `delete text fragment by invalid id throws exception`() = runBlocking {
+        val exception = assertFailsWith<IllegalArgumentException> {
+            service.deleteTextFragmentById(-1)
+        }
+        assertEquals("ID cannot be negative", exception.message)
+    }
+
+    @Test
+    fun `get all text fragments returns list of fragments`() = runBlocking {
+        val result = service.getAllTextFragments()
+        assertEquals(listOf(validFragment), result)
+    }
+}

--- a/backend/src/test/kotlin/com/example/services/TextServiceTest.kt
+++ b/backend/src/test/kotlin/com/example/services/TextServiceTest.kt
@@ -1,0 +1,96 @@
+package com.example.services
+
+import com.example.model.Text
+import com.example.repository.TextRepository
+import com.example.service.TextService
+import com.example.service.TextServiceImpl
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.todayIn
+import org.junit.jupiter.api.assertDoesNotThrow
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class TextServiceTest {
+    private lateinit var service: TextService
+    private val text = Text(1, "Text", listOf(0, 1, 2), "Text", Clock.System.todayIn(TimeZone.currentSystemDefault()))
+    private val textWithEmptyFields =
+        Text(1, "", listOf(0, 1, 2), "", Clock.System.todayIn(TimeZone.currentSystemDefault()))
+    private val repository = mockk<TextRepository>(relaxed = true)
+
+    @BeforeTest
+    fun setup() {
+        service = TextServiceImpl(repository)
+
+        coEvery { repository.getTextById(1) } returns text
+        coEvery { repository.getTextById(-1) } throws IllegalArgumentException("ID cannot be negative")
+        coEvery { repository.getTextById(2) } returns null
+        coEvery { repository.addText(text) } returns 1
+        coEvery { repository.updateText(text) } returns 1
+        coEvery { repository.deleteTextById(1) } returns 1
+        coEvery { repository.getAllTexts() } returns listOf(text)
+    }
+
+    @Test
+    fun `test get text by valid id returns text`() = runBlocking {
+        assertEquals(text, service.getTextById(1))
+    }
+
+    @Test
+    fun `test get text by invalid id throws exception`() = runBlocking {
+        val exception = assertFailsWith<IllegalArgumentException> { service.getTextById(-1) }
+        assertEquals("ID cannot be negative", exception.message)
+    }
+
+    @Test
+    fun `test get text by non-existent id throws NoSuchElementException`() = runBlocking {
+        val exception = assertFailsWith<NoSuchElementException> { service.getTextById(2) }
+        assertEquals("No text found with id 2", exception.message)
+    }
+
+    @Test
+    fun `test add valid text`() = runBlocking {
+        assertDoesNotThrow { service.addText(text) }
+        coVerify { repository.addText(text) }
+    }
+
+    @Test
+    fun `test add text with empty fields throws exception`() = runBlocking {
+        val exception = assertFailsWith<IllegalArgumentException> { service.addText(textWithEmptyFields) }
+        assertEquals("Text cannot be empty", exception.message)
+    }
+
+    @Test
+    fun `test update valid text`() = runBlocking {
+        assertTrue(service.updateText(text))
+    }
+
+    @Test
+    fun `test update text with empty fields throws exception`() = runBlocking {
+        val exception = assertFailsWith<IllegalArgumentException> { service.updateText(textWithEmptyFields) }
+        assertEquals("Text cannot be empty", exception.message)
+    }
+
+    @Test
+    fun `test delete text by valid id`() = runBlocking {
+        assertTrue(service.deleteTextById(1))
+    }
+
+    @Test
+    fun `test delete text by invalid id throws exception`() = runBlocking {
+        val exception = assertFailsWith<IllegalArgumentException> { service.deleteTextById(-1) }
+        assertEquals("ID cannot be negative", exception.message)
+    }
+
+    @Test
+    fun `test get all texts returns list of texts`() = runBlocking {
+        assertEquals(listOf(text), service.getAllTexts())
+    }
+}

--- a/backend/src/test/kotlin/com/example/services/UserServiceTest.kt
+++ b/backend/src/test/kotlin/com/example/services/UserServiceTest.kt
@@ -1,0 +1,65 @@
+package com.example.services
+
+import com.example.model.ExposedUser
+import com.example.repository.UserRepository
+import com.example.service.UserService
+import com.example.service.UserServiceImpl
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class UserServiceTest {
+    private lateinit var setvice: UserService
+    private val EXCEPTION_MESSAGE: String = "An operation is not implemented: Not yet implemented"
+
+    @BeforeTest
+    fun setup() {
+        var repository = mockk<UserRepository>(relaxed = true)
+        setvice = UserServiceImpl(repository)
+    }
+
+    @Test
+    fun `test createUser throws NotImplementedError`() = runBlocking {
+        var user = ExposedUser("", 0)
+        var exception = assertFailsWith<NotImplementedError> {
+            setvice.createUser(user)
+        }
+        assertEquals(EXCEPTION_MESSAGE, exception.message)
+    }
+
+    @Test
+    fun `test updateUser throws NotImplementedError`() = runBlocking {
+        var user = ExposedUser("", 0)
+        var exception = assertFailsWith<NotImplementedError> {
+            setvice.updateUser(1, user)
+        }
+        assertEquals(EXCEPTION_MESSAGE, exception.message)
+    }
+
+    @Test
+    fun `test deleteUser throws NotImplementedError`() = runBlocking {
+        var exception = assertFailsWith<NotImplementedError> {
+            setvice.deleteUser(1)
+        }
+        assertEquals(EXCEPTION_MESSAGE, exception.message)
+    }
+
+    @Test
+    fun `test getAllUsers throws NotImplementedError`() = runBlocking {
+        var exception = assertFailsWith<NotImplementedError> {
+            setvice.getAllUsers()
+        }
+        assertEquals(EXCEPTION_MESSAGE, exception.message)
+    }
+
+    @Test
+    fun `test getUserById throws NotImplementedError`() = runBlocking {
+        var exception = assertFailsWith<NotImplementedError> {
+            setvice.getUserById(1)
+        }
+        assertEquals(EXCEPTION_MESSAGE, exception.message)
+    }
+}

--- a/backend/src/test/kotlin/com/example/services/UserServiceTest.kt
+++ b/backend/src/test/kotlin/com/example/services/UserServiceTest.kt
@@ -12,20 +12,20 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class UserServiceTest {
-    private lateinit var setvice: UserService
+    private lateinit var service: UserService
     private val EXCEPTION_MESSAGE: String = "An operation is not implemented: Not yet implemented"
 
     @BeforeTest
     fun setup() {
         var repository = mockk<UserRepository>(relaxed = true)
-        setvice = UserServiceImpl(repository)
+        service = UserServiceImpl(repository)
     }
 
     @Test
     fun `test createUser throws NotImplementedError`() = runBlocking {
         var user = ExposedUser("", 0)
         var exception = assertFailsWith<NotImplementedError> {
-            setvice.createUser(user)
+            service.createUser(user)
         }
         assertEquals(EXCEPTION_MESSAGE, exception.message)
     }
@@ -34,7 +34,7 @@ class UserServiceTest {
     fun `test updateUser throws NotImplementedError`() = runBlocking {
         var user = ExposedUser("", 0)
         var exception = assertFailsWith<NotImplementedError> {
-            setvice.updateUser(1, user)
+            service.updateUser(1, user)
         }
         assertEquals(EXCEPTION_MESSAGE, exception.message)
     }
@@ -42,7 +42,7 @@ class UserServiceTest {
     @Test
     fun `test deleteUser throws NotImplementedError`() = runBlocking {
         var exception = assertFailsWith<NotImplementedError> {
-            setvice.deleteUser(1)
+            service.deleteUser(1)
         }
         assertEquals(EXCEPTION_MESSAGE, exception.message)
     }
@@ -50,7 +50,7 @@ class UserServiceTest {
     @Test
     fun `test getAllUsers throws NotImplementedError`() = runBlocking {
         var exception = assertFailsWith<NotImplementedError> {
-            setvice.getAllUsers()
+            service.getAllUsers()
         }
         assertEquals(EXCEPTION_MESSAGE, exception.message)
     }
@@ -58,7 +58,7 @@ class UserServiceTest {
     @Test
     fun `test getUserById throws NotImplementedError`() = runBlocking {
         var exception = assertFailsWith<NotImplementedError> {
-            setvice.getUserById(1)
+            service.getUserById(1)
         }
         assertEquals(EXCEPTION_MESSAGE, exception.message)
     }


### PR DESCRIPTION
Close #29: _Add routes and tests for text fragments_

Previously added text routes, but overlooked fragment routes, believing they were excluded from our working plan.